### PR TITLE
fix: Organized organization name

### DIFF
--- a/components/Domains/Footer/index.vue
+++ b/components/Domains/Footer/index.vue
@@ -10,7 +10,7 @@
       </n-link>
     </h2>
     <div class="flex flex-col items-center justify-end sm:items-start">
-      <h3 class="mb-2">主催: 一般社団法人PyCon JP</h3>
+      <h3 class="mb-2">主催: 一般社団法人PyCon JP Association</h3>
       <h3 class="text-center">
         PyCon JP 2020 in Tokyo is a production of the
         <a
@@ -19,7 +19,7 @@
           target="_blank"
           rel="noopener noreferrer"
         >
-          PyCon JP Committee
+          PyCon JP Association
         </a>
       </h3>
     </div>


### PR DESCRIPTION
## Purpose

PyCon JP Committee was changed thier organization name, "PyCon JP Association" in this March.

https://www.pycon.jp/committee/charter.html

## Screanshot

<img width="1148" alt="Screenshot_2" src="https://user-images.githubusercontent.com/6592904/84385064-ec850a80-ac29-11ea-9723-bb4b9fcc7255.png">
