### PR TITLE
do not open menu on initial loading

### DIFF
--- a/components/Domains/Header/index.vue
+++ b/components/Domains/Header/index.vue
@@ -78,7 +78,7 @@ export default {
       isDrawerOpen: false,
       isDropdownOpen: false,
       isEventListDropdownOpen: false,
-      isMobile: false,
+      isMobile: true,
     }
   },
   computed: {


### PR DESCRIPTION
モバイルメニューが初回起動時に表示されないように変更。

その代わりデスクトップの初回起動時メニューが遅れてから表示されるようになってます。

https://github.com/pyconjp/pycon.jp.2020.ui/issues/24#issue-639636797